### PR TITLE
Add offset property

### DIFF
--- a/firebolt/arrays/base.mojo
+++ b/firebolt/arrays/base.mojo
@@ -20,9 +20,10 @@ struct ArrayData(Copyable, Movable, Writable):
     var bitmap: ArcPointer[Bitmap]
     var buffers: List[ArcPointer[Buffer]]
     var children: List[ArcPointer[ArrayData]]
+    var offset: Int
 
     fn is_valid(self, index: Int) -> Bool:
-        return self.bitmap[].unsafe_get(index)
+        return self.bitmap[].unsafe_get(index + self.offset)
 
     fn as_primitive[T: DataType](self) raises -> PrimitiveArray[T]:
         return PrimitiveArray[T](self)
@@ -76,7 +77,7 @@ struct ArrayData(Copyable, Movable, Writable):
 
         for i in range(self.length):
             if self.is_valid(i):
-                writer.write(self.buffers[0][].unsafe_get(i))
+                writer.write(self.buffers[0][].unsafe_get(i + self.offset))
             else:
                 writer.write("-")
             writer.write(" ")

--- a/firebolt/arrays/binary.mojo
+++ b/firebolt/arrays/binary.mojo
@@ -40,6 +40,7 @@ struct StringArray(Array):
             bitmap=self.bitmap,
             buffers=List(self.offsets, self.values),
             children=List[ArcPointer[ArrayData]](),
+            offset=0,
         )
 
     fn __moveinit__(out self, deinit existing: Self):
@@ -74,14 +75,14 @@ struct StringArray(Array):
         self.bitmap[].unsafe_set(index, True)
         self.offsets[].unsafe_set[DType.uint32](index + 1, next_offset)
         self.values[].grow[DType.uint8](next_offset)
-        var dst_address = self.values[].offset(Int(last_offset))
+        var dst_address = self.values[].get_ptr_at(Int(last_offset))
         var src_address = value.unsafe_ptr()
         memcpy(dst_address, src_address, len(value))
 
     fn unsafe_get(self, index: UInt) -> StringSlice[__origin_of(self)]:
         var start_offset = self.offsets[].unsafe_get[DType.uint32](index)
         var end_offset = self.offsets[].unsafe_get[DType.uint32](index + 1)
-        var address = self.values[].offset(Int(start_offset))
+        var address = self.values[].get_ptr_at(Int(start_offset))
         var length = UInt(Int(end_offset - start_offset))
         return StringSlice[__origin_of(self)](ptr=address, length=length)
 
@@ -96,6 +97,6 @@ struct StringArray(Array):
                 " length"
             )
 
-        var dst_address = self.values[].offset(Int(start_offset))
+        var dst_address = self.values[].get_ptr_at(Int(start_offset))
         var src_address = value.unsafe_ptr()
         memcpy(dst_address, src_address, length)

--- a/firebolt/arrays/chunked_array.mojo
+++ b/firebolt/arrays/chunked_array.mojo
@@ -47,6 +47,7 @@ struct ChunkedArray:
             bitmap=bitmap,
             buffers=List[ArcPointer[Buffer]](),
             children=List[ArcPointer[ArrayData]](),
+            offset=0,
         )
         var start = 0
         for chunk in self.chunks:

--- a/firebolt/arrays/nested.mojo
+++ b/firebolt/arrays/nested.mojo
@@ -42,6 +42,7 @@ struct ListArray(Array):
             bitmap=self.bitmap,
             buffers=List(self.offsets),
             children=List(self.values),
+            offset=0,
         )
 
     fn __moveinit__(out self, deinit existing: Self):
@@ -93,6 +94,7 @@ struct StructArray(Array):
             bitmap=self.bitmap,
             buffers=List[ArcPointer[Buffer]](),
             children=List[ArcPointer[ArrayData]](),
+            offset=0,
         )
 
     fn __moveinit__(out self, deinit existing: Self):

--- a/firebolt/arrays/tests/test_base.mojo
+++ b/firebolt/arrays/tests/test_base.mojo
@@ -3,5 +3,90 @@ from testing import assert_true, assert_false, assert_equal
 from memory import UnsafePointer, ArcPointer
 from firebolt.arrays.base import ArrayData
 from firebolt.buffers import Buffer, Bitmap
-from firebolt.dtypes import DType, int8
+from firebolt.dtypes import DType, int8, uint8
 from firebolt.test_fixtures.arrays import build_array_data, assert_bitmap_set
+
+
+def test_array_data_with_offset():
+    """Test ArrayData with offset functionality."""
+    # Create ArrayData with offset
+    var bitmap = ArcPointer(Bitmap.alloc(10))
+    var buffer = ArcPointer(Buffer.alloc[int8.native](10))
+
+    # Set some data in the buffer
+    buffer[].unsafe_set[int8.native](2, 100)
+    buffer[].unsafe_set[int8.native](3, 200)
+    buffer[].unsafe_set[int8.native](4, 300)
+
+    # Set validity bits
+    bitmap[].unsafe_set(2, True)
+    bitmap[].unsafe_set(3, True)
+    bitmap[].unsafe_set(4, True)
+
+    # Create ArrayData with offset=2
+    var array_data = ArrayData(
+        dtype=int8,
+        length=3,
+        bitmap=bitmap,
+        buffers=List(buffer),
+        children=List[ArcPointer[ArrayData]](),
+        offset=2,
+    )
+
+    assert_equal(array_data.offset, 2)
+
+    # Test is_valid with offset
+    assert_true(array_data.is_valid(0))  # Should check bitmap[2]
+    assert_true(array_data.is_valid(1))  # Should check bitmap[3]
+    assert_true(array_data.is_valid(2))  # Should check bitmap[4]
+
+
+def test_array_data_fieldwise_init():
+    """Test that @fieldwise_init decorator works with offset field."""
+    var bitmap = ArcPointer(Bitmap.alloc(5))
+    var buffer = ArcPointer(Buffer.alloc[int8.native](5))
+
+    # Test creating ArrayData with all fields specified including offset
+    var array_data = ArrayData(
+        dtype=int8,
+        length=5,
+        bitmap=bitmap,
+        buffers=List(buffer),
+        children=List[ArcPointer[ArrayData]](),
+        offset=3,
+    )
+
+    assert_equal(array_data.dtype, int8)
+    assert_equal(array_data.length, 5)
+    assert_equal(array_data.offset, 3)
+
+
+def test_array_data_write_to_with_offset():
+    """Test ArrayData write_to method respects offset."""
+
+    var bitmap = ArcPointer(Bitmap.alloc(10))
+    var buffer = ArcPointer(Buffer.alloc[DType.uint8](10))
+
+    # Set up data with values at positions 1,2,3
+    buffer[].unsafe_set[DType.uint8](1, 10)
+    buffer[].unsafe_set[DType.uint8](2, 11)
+    buffer[].unsafe_set[DType.uint8](3, 12)
+
+    # Set validity for positions 1,2,3
+    bitmap[].unsafe_set(1, True)
+    bitmap[].unsafe_set(2, True)
+    bitmap[].unsafe_set(3, True)
+
+    # Create ArrayData with offset=1, so logical indices 0,1,2 map to physical indices 1,2,3
+    var array_data = ArrayData(
+        dtype=uint8,
+        length=3,
+        bitmap=bitmap,
+        buffers=List(buffer),
+        children=List[ArcPointer[ArrayData]](),
+        offset=1,
+    )
+
+    var writer = String()
+    writer.write(array_data)
+    assert_equal(writer.strip(), "10 11 12")

--- a/firebolt/arrays/tests/test_nested.mojo
+++ b/firebolt/arrays/tests/test_nested.mojo
@@ -33,3 +33,23 @@ def test_list_bool_array():
     bools.append(as_bool_array_scalar(True))
     lists.unsafe_append(True)
     assert_equal(len(lists), 1)
+
+
+def test_struct_array():
+    var fields = List[Field](
+        Field("id", int64),
+        Field("name", string),
+        Field("active", bool_),
+    )
+
+    var struct_arr = StructArray(fields, capacity=10)
+    assert_equal(len(struct_arr), 0)
+    assert_equal(struct_arr.capacity, 10)
+
+    var data = struct_arr.as_data()
+    assert_equal(data.length, 0)
+    assert_true(data.dtype.is_struct())
+    assert_equal(len(data.dtype.fields), 3)
+    assert_equal(data.dtype.fields[0].name, "id")
+    assert_equal(data.dtype.fields[1].name, "name")
+    assert_equal(data.dtype.fields[2].name, "active")

--- a/firebolt/c_data.mojo
+++ b/firebolt/c_data.mojo
@@ -285,6 +285,7 @@ struct CArrowArray(Copyable, Movable):
             bitmap=bitmap,
             buffers=buffers,
             children=children,
+            offset=Int(self.offset),
         )
 
 

--- a/firebolt/test_fixtures/arrays.mojo
+++ b/firebolt/test_fixtures/arrays.mojo
@@ -43,6 +43,7 @@ def build_array_data(length: Int, nulls: Int) -> ArrayData:
         bitmap=ArcPointer(bitmap^),
         buffers=buffers,
         children=List[ArcPointer[ArrayData]](),
+        offset=0,
     )
 
 


### PR DESCRIPTION
The C++ implementation is relying on an offset property. This is useful when trying to implement unsafe_get for ListArray, for example.

Also rename the existing offset function to get_ptr_at.