### PR TITLE
Feature: primitive array fixes for writable and append

### DIFF
--- a/firebolt/arrays/primitive.mojo
+++ b/firebolt/arrays/primitive.mojo
@@ -155,7 +155,7 @@ struct PrimitiveArray[T: DataType](Array):
 
     fn append(mut self, value: Self.scalar):
         if self.data.length >= self.capacity:
-            self.grow(self.capacity * 2)
+            self.grow(max(self.capacity * 2, self.data.length + 1))
         self.unsafe_append(value)
 
     # fn append(mut self, value: Optional[Self.scalar]):
@@ -199,7 +199,9 @@ struct PrimitiveArray[T: DataType](Array):
         writer.write(", buffer=[")
         for i in range(self.capacity):
             if self.is_valid(i):
-                writer.write(self.buffer[].unsafe_get(i + self.offset))
+                writer.write(
+                    self.buffer[].unsafe_get[T.native](i + self.offset)
+                )
             else:
                 writer.write("NULL")
             writer.write(", ")

--- a/firebolt/arrays/tests/test_primitive.mojo
+++ b/firebolt/arrays/tests/test_primitive.mojo
@@ -35,14 +35,15 @@ def test_boolean_array():
     var b = d.as_primitive[bool_]()
 
 
-def test_e():
+def test_append():
     var a = Int8Array()
     assert_equal(len(a), 0)
     assert_equal(a.capacity, 0)
-    a.unsafe_append(1)
-    a.unsafe_append(2)
-    a.unsafe_append(3)
+    a.append(1)
+    a.append(2)
+    a.append(3)
     assert_equal(len(a), 3)
+    assert_true(a.capacity >= len(a))
 
 
 def test_array_from_ints():
@@ -256,5 +257,17 @@ def test_primitive_array_repr():
         (
             "PrimitiveArray( dtype=DataType(code=uint8), offset=0, capacity=5,"
             " buffer=[255, 128, NULL, NULL, NULL, ])"
+        ),
+    )
+
+    var arr64 = Int64Array()
+    arr64.append(1)
+    arr64.append(3)
+    arr64.append(5)
+    assert_equal(
+        arr64.__repr__(),
+        (
+            "PrimitiveArray( dtype=DataType(code=int64), offset=0, capacity=4,"
+            " buffer=[1, 3, 5, NULL, ])"
         ),
     )


### PR DESCRIPTION
Writable was only working correctly for int8 PrimitiveArray, fixed.

Also if you appending to a PrimitiveArray of initial capacity 0 it would never really grow.