### PR TITLE
Feature: generalize list unsafe_get

### DIFF
--- a/firebolt/arrays/nested.mojo
+++ b/firebolt/arrays/nested.mojo
@@ -83,12 +83,6 @@ struct ListArray(Array):
     fn unsafe_get(self, index: Int) raises -> ArrayData:
         """Access the value at a given index in the list array."""
         var child_dtype = self.data.dtype.fields[0].dtype
-        if not child_dtype.is_numeric():
-            raise Error(
-                "Only numeric dtype supported right now, got {}".format(
-                    child_dtype
-                )
-            )
         var start = Int(self.offsets[].unsafe_get[DType.int32](index))
         var end = Int(self.offsets[].unsafe_get[DType.int32](index + 1))
         ref first_child = self.data.children[0][]
@@ -98,7 +92,7 @@ struct ListArray(Array):
             buffers=first_child.buffers,
             offset=self.data.offset + start,
             length=end - start,
-            children=List[ArcPointer[ArrayData]](),
+            children=first_child.children,
         )
 
     fn write_to[W: Writer](self, mut writer: W):

--- a/firebolt/arrays/tests/test_nested.mojo
+++ b/firebolt/arrays/tests/test_nested.mojo
@@ -35,6 +35,26 @@ def test_list_bool_array():
 
     var lists = ListArray(bools^)
     assert_equal(len(lists), 1)
+    var first_value = lists.unsafe_get(0)
+
+    fn get(index: Int) -> Bool:
+        return first_value.buffers[0][].unsafe_get[DType.bool](index)
+
+    assert_equal(get(0), True)
+    assert_equal(get(1), False)
+    assert_equal(get(2), True)
+
+
+def test_list_str():
+    var strings = StringArray()
+    strings.unsafe_append("hello")
+    strings.unsafe_append("world")
+
+    var lists = ListArray(strings^)
+    var first_value = StringArray(lists.unsafe_get(0))
+
+    assert_equal(first_value.unsafe_get(0), "hello")
+    assert_equal(first_value.unsafe_get(1), "world")
 
 
 def test_struct_array():
@@ -83,8 +103,3 @@ def test_struct_array_str_repr():
     assert_equal(str_repr, "StructArray(length=0)")
     assert_equal(repr_repr, "StructArray(length=0)")
     assert_equal(str_repr, repr_repr)
-
-
-fn main() raises -> None:
-    """Main entry point to get stdout during testing."""
-    test_list_int_array()


### PR DESCRIPTION
Generalize unsafe_get for ListArray by properly propagating the children to the output ArrayData.
And remove the check.

One test added for ListArray of StringArray.