### PR TITLE
Feature: introduce a formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,23 @@ assert_equal(len(lists), 1)
 assert_equal(lists.data.dtype, list_(int64))
 ```
 
+### Formatting arrays for display
+
+```mojo
+from firebolt.io import Formatter
+from firebolt.arrays import array
+from firebolt.dtypes import int32
+
+var arr = array[int32](1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+var output = String()
+var formatter = Formatter(limit=3)  # Show first 3 elements
+formatter.format(output, arr)
+print(output)
+# Output: PrimitiveArray[DataType(code=int32)]([1, 2, 3, ...])
+```
+
+The formatter supports all array types including nested structures like lists and structs, and automatically handles NULL values.
+
 ### Zero-copy access of a PyArrow array in Mojo
 
 For more details see the [Arrow C Data Interface](https://arrow.apache.org/docs/format/CDataInterface.html).

--- a/firebolt/arrays/__init__.mojo
+++ b/firebolt/arrays/__init__.mojo
@@ -4,14 +4,8 @@ from .nested import *
 from .primitive import *
 
 
-# fn array[T: DType](*values: Scalar[T]) -> PrimitiveArray[DataType(T)]:
-#     var a = PrimitiveArray[DataType(T)](len(values))
-#     for value in values:
-#         a.unsafe_append(value)
-#     return a^
-
-
 fn array[T: DataType](*values: Scalar[T.native]) -> PrimitiveArray[T]:
+    """Create a primitive array with the given values."""
     var a = PrimitiveArray[T](len(values))
     for value in values:
         a.unsafe_append(value)

--- a/firebolt/arrays/tests/test_primitive.mojo
+++ b/firebolt/arrays/tests/test_primitive.mojo
@@ -222,10 +222,7 @@ def test_primitive_array_write_to_large_array():
 
 def test_primitive_array_str():
     """Test __str__ method returns formatted string representation."""
-    var arr = Int32Array(5)
-    arr.append(42)
-    arr.append(84)
-    arr.append(126)
+    var arr = array[int32](42, 84, 126)
 
     var result = arr.__str__()
     assert_true("PrimitiveArray(" in result)

--- a/firebolt/buffers.mojo
+++ b/firebolt/buffers.mojo
@@ -166,7 +166,7 @@ struct Buffer(Movable):
         return count
 
 
-struct Bitmap(Movable, Writable):
+struct Bitmap(Movable, Representable, Stringable, Writable):
 
     """Hold information about the null records in an array."""
 
@@ -205,6 +205,16 @@ struct Bitmap(Movable, Writable):
             if i > 16:
                 writer.write("...")
                 break
+
+    fn __str__(self) -> String:
+        var output = String()
+        output.write(self)
+        return output
+
+    fn __repr__(self) -> String:
+        var output = String()
+        output.write(self)
+        return output
 
     fn unsafe_get(self, index: Int) -> Bool:
         return self.buffer.unsafe_get[DType.bool](index + self.offset)
@@ -414,7 +424,6 @@ struct Bitmap(Movable, Writable):
                     start_index += 1
                 if bit_pos_end != 0:
                     self.partial_byte_set(end_index, 0, bit_pos_end, value)
-                    end_index -= 1
 
         # Now take care of the full bytes.
         if end_index > start_index:

--- a/firebolt/dtypes.mojo
+++ b/firebolt/dtypes.mojo
@@ -424,3 +424,17 @@ alias float32 = DataType(code=FLOAT32, native=DType.float32)
 alias float64 = DataType(code=FLOAT64, native=DType.float64)
 alias string = DataType(code=STRING)
 alias binary = DataType(code=BINARY)
+
+alias all_numeric_dtypes = [
+    int8,
+    int16,
+    int32,
+    int64,
+    uint8,
+    uint16,
+    uint32,
+    uint64,
+    float16,
+    float32,
+    float64,
+]

--- a/firebolt/io/__init__.mojo
+++ b/firebolt/io/__init__.mojo
@@ -1,0 +1,3 @@
+"""IO utilities for formatting and displaying Firebolt arrays."""
+
+from .formatter import Formatter

--- a/firebolt/io/formatter.mojo
+++ b/firebolt/io/formatter.mojo
@@ -1,0 +1,103 @@
+from firebolt.arrays import *
+from firebolt.dtypes import *
+
+
+struct Formatter:
+    """Recursively formats and prints ArrayData and typed arrays."""
+
+    # How many elements to print.
+    var limit: Int
+
+    fn __init__(out self, limit: Int = 3):
+        self.limit = limit
+
+    fn format[
+        T: DataType, //, W: Writer
+    ](self, mut writer: W, value: PrimitiveArray[T]) raises:
+        """Output a PrimitiveArray to the given Writer."""
+        writer.write("PrimitiveArray[")
+        writer.write(materialize[value.dtype]())
+        writer.write("]([")
+
+        for i in range(value.data.length):
+            if i > 0:
+                writer.write(", ")
+            if i >= self.limit:
+                writer.write("...")
+                break
+
+            if value.is_valid(i):
+                writer.write(value.unsafe_get(i))
+            else:
+                writer.write("NULL")
+        writer.write("])")
+
+    fn format[W: Writer](self, mut writer: W, value: ListArray) raises:
+        """Output a ListArray to the given Writer."""
+        writer.write("ListArray([")
+        for i in range(value.data.length):
+            if i > 0:
+                writer.write(", ")
+            if i >= self.limit:
+                writer.write("...")
+                break
+
+            if value.is_valid(i):
+                self.format(writer, value.unsafe_get(i))
+            else:
+                writer.write("NULL")
+        writer.write("])")
+
+    fn format[W: Writer](self, mut writer: W, value: StringArray) raises:
+        """Output a StringArray to the given Writer."""
+        writer.write("StringArray([")
+        for i in range(value.data.length):
+            if i > 0:
+                writer.write(", ")
+            if i >= self.limit:
+                writer.write("...")
+                break
+
+            if value.is_valid(i):
+                writer.write(value.unsafe_get(i))
+            else:
+                writer.write("NULL")
+        writer.write("])")
+
+    fn format[W: Writer](self, mut writer: W, array_data: ArrayData) raises:
+        """Output a dynamic ArrayData to the given writer."""
+        if array_data.dtype.is_numeric():
+
+            @parameter
+            for dtype in all_numeric_dtypes:
+                if array_data.dtype == materialize[dtype]():
+                    self.format(
+                        writer,
+                        PrimitiveArray[dtype](data=array_data.copy()),
+                    )
+                    return
+        elif array_data.dtype.is_list():
+            self.format(writer, ListArray(array_data.copy()))
+            return
+        elif array_data.dtype.is_struct():
+            self.format(writer, StructArray(data=array_data.copy()))
+            return
+        elif array_data.dtype.is_string():
+            self.format(writer, StringArray(data=array_data.copy()))
+            return
+        raise Error("Unknown dtype {} in format.".format(array_data.dtype))
+
+    fn format[W: Writer](self, mut writer: W, value: StructArray) raises:
+        """Output a StructArray to the Writer."""
+        writer.write("StructArray({")
+        if len(value.data.children) > 0:
+            for i in range(len(value.fields)):
+                if i > 0:
+                    writer.write(", ")
+                ref field = value.fields[i]
+                writer.write("'")
+                writer.write(field.name)
+                writer.write("': ")
+                ref field_value = value.unsafe_get(field.name)
+                self.format(writer, field_value)
+        writer.write("})")

--- a/firebolt/io/tests/test_formatter.mojo
+++ b/firebolt/io/tests/test_formatter.mojo
@@ -1,0 +1,159 @@
+from testing import assert_equal, assert_true, assert_false
+
+from firebolt.arrays import *
+from firebolt.dtypes import *
+from firebolt.io.formatter import Formatter
+from firebolt.test_fixtures.arrays import (
+    build_list_of_list,
+    build_list_of_int,
+    build_struct,
+)
+
+
+def test_primitive_array():
+    """Test the formatter for a primitive array."""
+    var arr = array[int32](42, 84, 126)
+
+    var output = String()
+    var formatter = Formatter()
+    formatter.format(output, arr)
+    assert_equal(
+        output,
+        """PrimitiveArray[DataType(code=int32)]([42, 84, 126])""",
+    )
+
+
+def test_list_int_array():
+    var arr = build_list_of_int[int64]()
+    var output = String()
+    var formatter = Formatter()
+    formatter.format(output, arr)
+    assert_equal(
+        output,
+        (
+            "ListArray([PrimitiveArray[DataType(code=int64)]([1, 2]),"
+            " PrimitiveArray[DataType(code=int64)]([3, 4]),"
+            " PrimitiveArray[DataType(code=int64)]([5, 6, 7]), ...])"
+        ),
+    )
+
+
+def test_list_list_array():
+    var arr = build_list_of_list[int16]()
+    var output = String()
+    var formatter = Formatter()
+    formatter.format(output, arr)
+    assert_equal(
+        output,
+        (
+            "ListArray([ListArray([PrimitiveArray[DataType(code=int16)]([1,"
+            " 2]), PrimitiveArray[DataType(code=int16)]([3, 4])]),"
+            " ListArray([PrimitiveArray[DataType(code=int16)]([5, 6, 7]),"
+            " PrimitiveArray[DataType(code=int16)]([]),"
+            " PrimitiveArray[DataType(code=int16)]([8])]),"
+            " ListArray([PrimitiveArray[DataType(code=int16)]([9, 10])]),"
+            " ...])"
+        ),
+    )
+
+
+def test_empty_struct():
+    var fields = List[Field](
+        Field("id", materialize[int64]()),
+        Field("name", materialize[string]()),
+        Field("active", materialize[bool_]()),
+    )
+
+    var struct_arr = StructArray(fields^, capacity=10)
+
+    var output = String()
+    var formatter = Formatter()
+    formatter.format(output, struct_arr)
+    assert_equal(
+        output,
+        "StructArray({})",
+    )
+
+
+def test_struct():
+    var struct_arr = build_struct()
+
+    var output = String()
+    var formatter = Formatter()
+    formatter.format(output, struct_arr)
+    assert_equal(
+        output,
+        (
+            "StructArray({'int_data_a': "
+            "PrimitiveArray[DataType(code=int32)]([1, 2, 3, ...]), "
+            "'int_data_b': PrimitiveArray[DataType(code=int32)]([10, 20, "
+            "30])})"
+        ),
+    )
+
+
+def test_formatter_with_different_limits():
+    """Test formatter with various limit values."""
+    var arr = array[int32](1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+
+    # Test limit=0
+    var output0 = String()
+    var formatter0 = Formatter(limit=0)
+    formatter0.format(output0, arr)
+    assert_equal(output0, "PrimitiveArray[DataType(code=int32)]([...])")
+
+    # Test limit=1
+    var output1 = String()
+    var formatter1 = Formatter(limit=1)
+    formatter1.format(output1, arr)
+    assert_equal(output1, "PrimitiveArray[DataType(code=int32)]([1, ...])")
+
+    # Test limit=10 (should show all elements)
+    var output10 = String()
+    var formatter10 = Formatter(limit=10)
+    formatter10.format(output10, arr)
+    assert_equal(
+        output10,
+        "PrimitiveArray[DataType(code=int32)]([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])",
+    )
+
+
+def test_empty_array():
+    """Test formatter with an empty array."""
+    var arr = Int32Array(0)
+
+    var output = String()
+    var formatter = Formatter()
+    formatter.format(output, arr)
+    assert_equal(output, "PrimitiveArray[DataType(code=int32)]([])")
+
+
+def test_all_null_array():
+    """Test formatter with an array of all NULL values."""
+    var arr = Int32Array(3)
+    arr.data.length = 3
+    arr.data.bitmap[].unsafe_range_set(0, 3, False)
+
+    var output = String()
+    var formatter = Formatter()
+    formatter.format(output, arr)
+    assert_equal(
+        output, "PrimitiveArray[DataType(code=int32)]([NULL, NULL, NULL])"
+    )
+
+
+def test_array_with_nulls():
+    """Test formatter with an array containing some NULL values."""
+    var arr = Int32Array(5)
+    arr.append(1)
+    arr.append(2)
+    arr.data.bitmap[].unsafe_set(2, False)  # Make third element NULL
+    arr.data.length = 3
+    arr.append(4)
+
+    var output = String()
+    var formatter = Formatter()
+    formatter.format(output, arr)
+    assert_equal(
+        output, "PrimitiveArray[DataType(code=int32)]([1, 2, NULL, ...])"
+    )

--- a/firebolt/test_fixtures/arrays.mojo
+++ b/firebolt/test_fixtures/arrays.mojo
@@ -1,7 +1,12 @@
-from firebolt.arrays import BoolArray, ArrayData
+from firebolt.arrays import (
+    BoolArray,
+    ArrayData,
+    ListArray,
+    StructArray,
+)
 from memory import ArcPointer
 from firebolt.buffers import Buffer, Bitmap
-from firebolt.dtypes import uint8
+from firebolt.dtypes import uint8, DataType, list_, int32, Field, struct_
 from testing import assert_equal
 from builtin._location import __call_location
 
@@ -67,3 +72,118 @@ def assert_bitmap_set(
             ).format(message, i, current_value, expected_value, list_pos),
             location=__call_location(),
         )
+
+
+fn build_list_of_int[data_type: DataType]() raises -> ListArray:
+    """Build a test ListArray that itself contains a ListArray of IntArrays."""
+    # Define all the values.
+    var bitmap = Bitmap.alloc(10)
+    bitmap.unsafe_range_set(0, 10, True)
+    var buffer = ArcPointer(Buffer.alloc[data_type.native](10))
+    for i in range(10):
+        buffer[].unsafe_set[data_type.native](i, i + 1)
+
+    var value_data = ArrayData(
+        dtype=materialize[data_type](),
+        length=10,
+        bitmap=ArcPointer(bitmap^),
+        buffers=List(buffer),
+        children=List[ArcPointer[ArrayData]](),
+        offset=0,
+    )
+
+    # Define the PrimitiveArrays.
+    var value_offset = ArcPointer(
+        Buffer.from_values[DType.int32](0, 2, 4, 7, 7, 8, 10)
+    )
+
+    var list_bitmap = ArcPointer(Bitmap.alloc(6))
+    list_bitmap[].unsafe_range_set(0, 6, True)
+    list_bitmap[].unsafe_set(3, False)
+    var list_data = ArrayData(
+        dtype=list_(materialize[data_type]()),
+        length=6,
+        buffers=List(value_offset),
+        children=List(ArcPointer(value_data^)),
+        bitmap=list_bitmap,
+        offset=0,
+    )
+    return ListArray(list_data^)
+
+
+fn build_list_of_list[data_type: DataType]() raises -> ListArray:
+    """Build a test ListArray that itself contains a ListArray of IntArrays.
+
+    See: https://elferherrera.github.io/arrow_guide/arrays_nested.html
+    """
+
+    # Define all the values.
+    var bitmap = ArcPointer(Bitmap.alloc(10))
+    bitmap[].unsafe_range_set(0, 10, True)
+    var buffer = ArcPointer(Buffer.alloc[data_type.native](10))
+    for i in range(10):
+        buffer[].unsafe_set[data_type.native](i, i + 1)
+
+    var value_data = ArrayData(
+        dtype=materialize[data_type](),
+        length=10,
+        bitmap=bitmap,
+        buffers=List(buffer),
+        children=List[ArcPointer[ArrayData]](),
+        offset=0,
+    )
+
+    # Define the PrimitiveArrays.
+    var value_offset = ArcPointer(
+        Buffer.from_values[DType.int32](0, 2, 4, 7, 7, 8, 10)
+    )
+
+    var list_bitmap = ArcPointer(Bitmap.alloc(6))
+    list_bitmap[].unsafe_range_set(0, 6, True)
+    list_bitmap[].unsafe_set(3, False)
+    var list_data = ArrayData(
+        dtype=list_(materialize[data_type]()),
+        length=6,
+        buffers=List(value_offset),
+        children=List(ArcPointer(value_data^)),
+        bitmap=list_bitmap,
+        offset=0,
+    )
+
+    # Now define the master array data.
+    var top_offsets = Buffer.from_values[DType.int32](0, 2, 5, 6)
+    var top_bitmap = ArcPointer(Bitmap.alloc(4))
+    top_bitmap[].unsafe_range_set(0, 4, True)
+    return ListArray(
+        ArrayData(
+            dtype=list_(list_(materialize[data_type]())),
+            length=4,
+            buffers=List(ArcPointer(top_offsets^)),
+            children=List(ArcPointer(list_data^)),
+            bitmap=top_bitmap,
+            offset=0,
+        )
+    )
+
+
+def build_struct() -> StructArray:
+    var int_data_a = ArrayData.from_buffer[int32](
+        Buffer.from_values[DType.int32](1, 2, 3, 4, 5), 5
+    )
+    var field_1 = Field("int_data_a", materialize[int32]())
+
+    var int_data_b = ArrayData.from_buffer[int32](
+        Buffer.from_values[DType.int32](10, 20, 30), 3
+    )
+    var field_2 = Field("int_data_b", materialize[int32]())
+    bitmap = Bitmap.alloc(2)
+    bitmap.unsafe_range_set(0, 2, True)
+    var struct_array_data = ArrayData(
+        dtype=struct_(List(field_1^, field_2^)),
+        length=2,
+        bitmap=ArcPointer(bitmap^),
+        offset=0,
+        buffers=List[ArcPointer[Buffer]](),
+        children=List(ArcPointer(int_data_a^), ArcPointer(int_data_b^)),
+    )
+    return StructArray(data=struct_array_data^)

--- a/firebolt/tests/test_buffers.mojo
+++ b/firebolt/tests/test_buffers.mojo
@@ -133,6 +133,11 @@ def _reset(mut bitmap: Bitmap):
 def test_unsafe_range_set():
     var bitmap = Bitmap.alloc(16)
 
+    bitmap.unsafe_range_set(0, 10, True)
+    assert_bitmap_set(bitmap, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], "range 0-10")
+    bitmap.unsafe_range_set(0, 10, False)
+    assert_bitmap_set(bitmap, [], "reset")
+
     bitmap.unsafe_range_set(0, 0, True)
     assert_bitmap_set(bitmap, [], "range 0")
 
@@ -283,3 +288,7 @@ def test_bitmap_moveinit_with_offset():
     var moved_bitmap = bitmap^
     assert_equal(moved_bitmap.offset, 2)
     assert_true(moved_bitmap.unsafe_get(0))
+
+
+def main():
+    test_unsafe_range_set()


### PR DESCRIPTION
Introduce a formatter. This is loosely inspired by the rust arrow code and solves the problem of needing recursive formatting for the nested types.

Also clean up some more the testing code.